### PR TITLE
Rooms based off area

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -5,5 +5,6 @@ dictionaries: []
 words:
   - hass
   - sonarjs
+  - mireds
 ignoreWords: []
 import: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
-        "@digital-alchemy/core": "^0.3.11",
-        "@digital-alchemy/hass": "^0.3.9",
+        "@digital-alchemy/core": "^0.3.12",
+        "@digital-alchemy/hass": "^0.3.20",
         "@digital-alchemy/synapse": "^0.3.5",
         "dayjs": "^1.11.10",
         "prom-client": "^15.1.1"
@@ -1170,9 +1170,9 @@
       }
     },
     "node_modules/@digital-alchemy/core": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@digital-alchemy/core/-/core-0.3.11.tgz",
-      "integrity": "sha512-/oTBkBC0mvD+xaSAGD+9TzHRdCuLHxyR+b6RmVuPHl+N0BLgT7XVzalfhbLJcCZO5EH+vRE/VX69NOmkAjPu5w==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@digital-alchemy/core/-/core-0.3.12.tgz",
+      "integrity": "sha512-aqPukCZ1Rnujh5iRN2zx4XsNlUIKp06s2uUZsLn6LrgJULSRS7XbAzQ3R+9Zgv47UvPXz+OxYaN5OPacYwlKAA==",
       "dependencies": {
         "chalk": "^5.3.0",
         "dayjs": "^1.11.10",
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/@digital-alchemy/hass": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@digital-alchemy/hass/-/hass-0.3.9.tgz",
-      "integrity": "sha512-uOmoXBttO6u2f5XPKLv3bmyAq/OGqI4+TY4VMbfW4ItaUK348IMbS+2JQOg3oA5SCLTH4sNBzaQen7PpT0wraw==",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@digital-alchemy/hass/-/hass-0.3.20.tgz",
+      "integrity": "sha512-Z2wcEVO2oqYrnnns8pUAJ1Uu8ovt0NiKB8+ytkh30EHqJNeECc5Rdi4nuvT+kgKoKZLsBFVvQPN0Xji7pT+VOg==",
       "dependencies": {
         "@digital-alchemy/core": "^0.3.11",
         "dayjs": "^1.11.10",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "@digital-alchemy/automation",
   "repository": "https://github.com/Digital-Alchemy-TS/automation",
   "homepage": "https://docs.digital-alchemy.app/Automation",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "scripts": {
     "build": "rm -rf dist/; tsc",
     "lint": "eslint src",
     "test": "./scripts/test.sh",
     "prepublishOnly": "npm run build",
-    "upgrade": "ncu -u; npm i"
+    "upgrade": "ncu -f '@digital-alchemy/*' -u; npm i"
   },
   "author": {
     "url": "https://github.com/zoe-codez",
@@ -25,8 +25,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@digital-alchemy/core": "^0.3.11",
-    "@digital-alchemy/hass": "^0.3.9",
+    "@digital-alchemy/core": "^0.3.12",
+    "@digital-alchemy/hass": "^0.3.20",
     "@digital-alchemy/synapse": "^0.3.5",
     "dayjs": "^1.11.10",
     "prom-client": "^15.1.1"

--- a/src/extensions/light-manager.extension.ts
+++ b/src/extensions/light-manager.extension.ts
@@ -14,6 +14,8 @@ import {
   ENTITY_STATE,
   GenericEntityDTO,
   PICK_ENTITY,
+  PICK_FROM_AREA,
+  TAreaId,
 } from "@digital-alchemy/hass";
 
 import { RoomDefinition } from "..";
@@ -77,11 +79,11 @@ export function LightManager({
    *
    * Same as RGB only, but will preferentially use color temp mode
    */
-  async function manageLight(
+  async function manageLight<ROOM extends TAreaId>(
     entity: ENTITY_STATE<PICK_ENTITY<"light">>,
-    scene: SceneDefinition,
+    scene: SceneDefinition<ROOM>,
   ) {
-    const entity_id = entity.entity_id as PICK_ENTITY<"light">;
+    const entity_id = entity.entity_id as PICK_FROM_AREA<ROOM, "light">;
     const expected = scene[entity_id] as SceneLightState;
     if (is.empty(expected)) {
       // ??
@@ -283,15 +285,15 @@ export function LightManager({
           // Notice already being emitted from room extension
           return [];
         }
-        return Object.keys(room.currentSceneDefinition.definition).filter(
-          key => {
-            if (!is.domain(key, "light")) {
-              return false;
-            }
-            // TODO: Introduce additional checks for items like rgb color
-            return room.currentSceneDefinition.definition[key].state !== "off";
-          },
-        );
+        const keys = Object.keys(current) as (keyof typeof current)[];
+        return keys.filter(key => {
+          if (!is.domain(key, "light")) {
+            return false;
+          }
+          const entity = current[key] as { state: string };
+          // TODO: Introduce additional checks for items like rgb color
+          return entity.state !== "off";
+        });
       }),
     ) as PICK_ENTITY<"light">[];
 


### PR DESCRIPTION
#### Changes

Instead of having rooms as a free floating concept, this PR tightly binds the concept of a room to an area in home assistant. 

The intent is to build off the area, creating 
Bind the concept of "rooms" directly to areas instead of allowing them to be free floating concepts
Entities used in scenes must be assigned to the area

> Note:
This MAY cause entity unique ids to shift for some entities. This will cause `synapse` to generate new entities using the same name

- `scene.bedroom_high` (unavailable) + `scene.bedroom_high_2` (new entity)

If this occurs, the following command can be used to purge all `synapse` entities allowing you a clean slate to re-create properly

```typescript
await eachSeries(hass.entity.byPlatform("synapse"), async entity_id => {
  await hass.entity.registry.removeEntity(entity_id);
});
```

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
