### PR TITLE
feat: area service

### DIFF
--- a/src/helpers/timer.mts
+++ b/src/helpers/timer.mts
@@ -1,0 +1,117 @@
+/* eslint-disable no-console */
+
+// Like Object.entries, but returns a more specific type
+// reference: https://news.ycombinator.com/item?id=36457557
+
+// expands object types one level deep
+type ObjectEntry<T> = {
+  [K in Exclude<keyof T, undefined>]: [K, T[K]];
+}[Exclude<keyof T, undefined>]
+
+export const objectEntries = Object.entries as <T>(o: T) => ObjectEntry<T>[]
+
+export const objectKeys = Object.keys as <T>(obj: T) => Array<keyof T>
+
+export interface Duration {
+  hours?: number
+  minutes?: number
+  seconds?: number
+}
+
+export type UseTimerOutput = ReturnType<typeof useTimer>
+
+export function useTimer() {
+  let startTime = 0
+  let endTime = 0
+  let duration = 0
+  let timeoutId: NodeJS.Timeout | null = null
+  let onEndAction: () => void
+
+  function start(cb?: () => void) {
+    console.log('[TIMER] Starting Timer!')
+
+    startTime = Date.now()
+    endTime = startTime + duration
+
+    timeoutId = setTimeout(() => {
+      console.log('[TIMER] Times up!')
+
+      // end callback
+      _onEnd()
+
+      _clearTimer()
+    }, duration)
+
+    // start callback
+    if (cb)
+      cb()
+  }
+
+  function stop() {
+    if (_getRemainingTime() <= 0 || !timeoutId)
+      return
+
+    _clearTimer()
+    console.log('[TIMER] Stopping Timer!')
+  }
+
+  function restart() {
+    console.log('[TIMER] Restarting Timer!')
+    _clearTimer()
+    start()
+  }
+
+  function onEnd(cb: () => void) {
+    onEndAction = cb
+  }
+
+  /**
+   * Set the timer duration
+   * @param timerDuration number (seconds)
+   */
+  function setDuration(timerDuration: Duration) {
+    const timeMultiplier: Record<keyof Duration, number> = {
+      hours: 1000 * 60 * 60,
+      minutes: 1000 * 60,
+      seconds: 1000,
+    }
+
+    const normalizedDuration = objectEntries(timerDuration).reduce(
+      (total, [k, v]) => (total += timeMultiplier[k] * v),
+      0,
+    )
+
+    console.log(
+      `[TIMER] Setting duration to ${normalizedDuration}. Input={${JSON.stringify(timerDuration)}}`,
+    )
+    duration = normalizedDuration
+  }
+
+  function hasTimeLeft() {
+    return _getRemainingTime() > 0
+  }
+
+  function _getRemainingTime() {
+    return endTime - Date.now()
+  }
+
+  function _clearTimer() {
+    clearTimeout(timeoutId)
+    timeoutId = null
+  }
+
+  // timers reached 0 callback
+  function _onEnd() {
+    if (onEndAction)
+      onEndAction()
+  }
+
+  return {
+    start,
+    stop,
+    restart,
+    onEnd,
+    hasTimeLeft,
+    setDuration,
+  }
+}

--- a/src/services/area.service.mts
+++ b/src/services/area.service.mts
@@ -1,0 +1,208 @@
+import type { ByIdProxy, PICK_ENTITY } from '@digital-alchemy/hass'
+import type { SceneControllerInput } from './scene.service.mjs'
+import { InternalError, type TServiceParams } from '@digital-alchemy/core'
+import { useTimer, type UseTimerOutput } from '../helpers/timer.mjs'
+import { sceneController } from './scene.service.mjs'
+
+// TODO: fix switch names & icons
+// TODO: Service should return hooks
+// TODO: see about integrating actual home assistant scenes
+// TODO: document better
+// TODO: get feedback
+// TODO: test
+
+type AreaState = 'vacant' | 'occupied'
+
+interface AreaServiceInput {
+  name: string
+  triggers?: ByIdProxy<PICK_ENTITY<'binary_sensor'>>[]
+  current?: (state: AreaState) => AreaState
+  scenes?: Pick<
+    SceneControllerInput,
+    'conditions' | 'definitions' | 'off' | 'triggers'
+  >
+}
+
+interface AreaServiceOptions {
+  triggerType?: 'motion'
+}
+
+/**
+ * Area Service
+ *
+ * Manages the state of an area, determining whether it is "occupied" or "vacant" based on presence triggers
+ * or a custom callback. Optionally integrates with scene controllers to adjust scenes based on area state.
+ *
+ * @param input.name - name for the area. Name is used to create various sensors & ui entities.
+ * @param input.triggers - home assistant entities that trigger presence updates. (motiton sensors etc)
+ * @param input.current - (optional) Custom function to determine occupancy state if not using motion sensors.
+ * @param input.scenes - (optional) Provide scenes for the area.
+ * @param opts.triggerType - (optional) Set to 'motion' if you are providing presence sensors for the area to monitor.
+ * No need to provide an input.current function, occupancy is handled by the service.
+ */
+export function defineAreaConfig(ctx: TServiceParams, input: AreaServiceInput, opts: AreaServiceOptions = {}) {
+  const {
+    triggerType,
+  } = opts
+
+  const {
+    name,
+    current,
+    scenes,
+    triggers,
+  } = input
+
+  let _getStateCurrentValue = current
+  let setTimeout: UseTimerOutput['setDuration']
+  const _triggers = [...triggers]
+  const actions: Record<string, (() => void)[]> = {
+    init: [],
+    occupied: [],
+    vacant: [],
+  }
+
+  if (triggerType === 'motion') {
+    const {
+      getAreaOccupancy,
+      timeout,
+      setTimeout: setSceneTimeout,
+    } = presenceController({ name, presenceSensors: triggers, ctx })
+
+    // set state sensor current function
+    _getStateCurrentValue = getAreaOccupancy
+
+    // pass setTimeout to scene controller
+    setTimeout = setSceneTimeout
+
+    // add timeout to state triggers
+    // @ts-expect-error - not sure how to properly type a synapse sensor vs hass sensor
+    _triggers.push(timeout)
+  }
+
+  if (!_getStateCurrentValue) {
+    throw new InternalError(
+      ctx.context,
+      `[AREA][${name.toUpperCase()}]`,
+      `No state current callback defined. Must either define current or set triggerType = motion`,
+    )
+  }
+
+  const state = ctx.synapse.sensor<{ state: AreaState }>({
+    context: ctx.context,
+    name: `${name} State`,
+    options: ['vacant', 'occupied'] as const,
+    state: {
+      onUpdate: _triggers,
+      current: () => _getStateCurrentValue(state.state),
+    },
+  })
+
+  function _onVacant() {
+    ctx.logger.info(`[AREA][${name.toUpperCase()}] Vacant`)
+  }
+
+  function _onOccupied() {
+    ctx.logger.info(`[AREA][${name.toUpperCase()}] Occupied`)
+  }
+
+  // scene controller
+  if (scenes) {
+    const { triggers, conditions, ...rest } = scenes
+
+    // add occupied condtion to scene condtions
+    const updatedConditions = [...conditions, () => state.state === 'occupied']
+
+    // add area state sensor to trigger scene state updates.
+    const updatedTriggers = [...triggers, state]
+
+    const { init } = sceneController({
+      ctx,
+      name,
+      conditions: updatedConditions,
+      setTimeout,
+      triggers: updatedTriggers,
+      ...rest,
+    })
+
+    actions.init.push(init)
+  }
+
+  function init() {
+    actions.init.forEach(action => action())
+
+    state.onUpdate((next, prev) => {
+      if (next.state === prev.state)
+        return
+
+      if (next.state === 'occupied')
+        _onOccupied()
+
+      if (next.state === 'vacant')
+        _onVacant()
+    })
+  }
+
+  ctx.lifecycle.onReady(() => init())
+}
+
+interface PresenceControllerInput {
+  ctx: TServiceParams
+  name: string
+  presenceSensors: ByIdProxy<PICK_ENTITY<'binary_sensor'>>[]
+}
+
+/**
+ * Presence Controller
+ *
+ * Monitors presence sensors. motion=occupied, vacant=no motion within timeout period.
+ *
+ * @returns
+ * - `getAreaOccupancy`: Function to determine occupancy state of the area.
+ * - `setTimeout`: Function to set the timeout duration.
+ * - `timeout`: timeout binary sensor. is_on=true indicates the timer has reached 0.
+ */
+export function presenceController(input: PresenceControllerInput) {
+  const { ctx, name, presenceSensors } = input
+
+  // sensor for timeout, to trigger area state update
+  const timeout = ctx.synapse.binary_sensor({
+    context: ctx.context,
+    name: `${name} presence timeout`,
+    is_on: false,
+  })
+
+  const { start, restart, setDuration, onEnd } = useTimer()
+
+  // set timeout state when timer ends
+  onEnd(() => timeout.is_on = true)
+
+  // update state based on presenseSensors
+  function getAreaOccupancy(state: AreaState) {
+    const hasMotion = presenceSensors.some(sensor => sensor.state === 'on')
+    const timedOut = timeout.is_on
+    const isOccupied = state === 'occupied'
+
+    if (timedOut && isOccupied)
+      return 'vacant'
+
+    if (!hasMotion)
+      return state
+
+    if (isOccupied) {
+      ctx.logger.info('[PRESENCE CONTROLLER] Occupied with motion. Re-upping timer.')
+      restart()
+      return 'occupied'
+    }
+    else {
+      ctx.logger.info('[PRESENCE CONTROLLER] Vacant with motion. Starting timer.')
+      start(() => timeout.is_on = false)
+      return 'occupied'
+    }
+  }
+
+  return {
+    getAreaOccupancy,
+    setTimeout: setDuration,
+    timeout,
+  }
+}

--- a/src/services/scene.service.mts
+++ b/src/services/scene.service.mts
@@ -1,0 +1,309 @@
+import type { ByIdProxy, PICK_ENTITY } from '@digital-alchemy/hass'
+import type { Duration, UseTimerOutput } from '../helpers/timer.mjs'
+import { InternalError, type TServiceParams } from '@digital-alchemy/core'
+
+export interface SceneDef {
+  name: string
+  on: Array<() => void>
+  off?: Array<() => void>
+  icon?: string
+  isDefault?: boolean
+  timeout?: Duration | (() => Duration)
+}
+export type ActivateSceneCondition = () => boolean
+
+type ParsedSceneMeta = Omit<SceneDef, 'timeout'> & { timeout: Duration }
+type Scenes = Map<string, SceneDef>
+
+export interface SceneControllerInput {
+  ctx: TServiceParams
+  name: string
+  conditions?: ActivateSceneCondition[]
+  definitions: SceneDef[]
+  /**
+   * Default functiton to turn off scenes.
+   * An off function in a scene definition will be used instead of this if defined.
+   * @returns
+   */
+  off: () => void
+  setTimeout?: UseTimerOutput['setDuration']
+  triggers?: ByIdProxy<PICK_ENTITY>[]
+}
+
+// overkill?
+interface SceneControllerOptions {
+  /** on activate hook */
+  onActivate?: (sceneMeta: ParsedSceneMeta) => void
+  /** on init hook */
+  onInit?: (sceneMeta: ParsedSceneMeta) => void
+  /** on off hook */
+  onOff?: (sceneMeta: ParsedSceneMeta) => void
+  /** on update hook */
+  onUpdate?: (sceneMeta: ParsedSceneMeta) => void
+}
+
+export function sceneController(
+  input: SceneControllerInput,
+  options: SceneControllerOptions = {},
+) {
+  const {
+    onActivate,
+    onInit,
+    onOff,
+    onUpdate,
+  } = options
+
+  const {
+    ctx,
+    name,
+    conditions = [],
+    definitions,
+    off: defaultOff,
+    setTimeout,
+    triggers,
+  } = input
+
+  const scenes = new Map<string, SceneDef>()
+
+  definitions.forEach(scene => scenes.set(scene.name, scene))
+
+  if (scenes.size === 0)
+    throw new Error(`[SCENE CONTROLLER] Error: No scene definitions.`)
+
+  const state = ctx.synapse.sensor<{ state: 'active' | 'idle' }>({
+    context: ctx.context,
+    name: `${name} Scene State`,
+    state: {
+      onUpdate: triggers,
+      current: () => {
+        const conditionsMet = conditions.every(c => c())
+
+        if (!conditionsMet) {
+          ctx.logger.info(`[SCENE CONTROLLER][ACTIVATE] Conditions not met.`)
+          return 'idle'
+        }
+
+        return 'active'
+      },
+    },
+    options: ['active', 'idle'] as const,
+  })
+
+  const activeScene = ctx.synapse.sensor<{ state: string }>({
+    context: ctx.context,
+    name: `${name} Scene Controller`,
+    state: 'default',
+    options: [...scenes.keys()] as const,
+  })
+
+  sceneUiControls({
+    ctx,
+    entityType: 'switch',
+    scenes,
+    // @ts-expect-error - not sure how to properly type a synapse sensor vs hass sensor
+    activeScene,
+    setScene,
+  })
+
+  function init() {
+    state.onUpdate((next, prev) => {
+      if (next.state === prev.state)
+        return
+
+      if (next.state === 'active')
+        activate()
+
+      if (next.state === 'idle')
+        off()
+    })
+
+    activeScene.onUpdate((next) => {
+      const sceneDef = _getSceneDef(next.state as string)
+      setTimeout(sceneDef.timeout)
+
+      if (state.state === 'active')
+        activate()
+
+      // on update hook
+      if (onUpdate)
+        onUpdate(sceneDef)
+    })
+
+    // on init hook
+    if (onInit)
+      onInit(_getSceneDef(activeScene.state))
+  }
+
+  function activate() {
+    const sceneMeta = _getSceneDef(activeScene.state)
+
+    ctx.logger.info('[SCENE CONTROLLER] Activating scene:', activeScene.state)
+
+    // on activate hook
+    if (onActivate)
+      onActivate(sceneMeta)
+
+    for (const callback of sceneMeta.on) callback()
+  }
+
+  function off() {
+    const sceneMeta = _getSceneDef(activeScene.state)
+
+    ctx.logger.info('[SCENE CONTROLLER] Turning off scene:', activeScene.state)
+
+    // on off hook
+    if (onOff)
+      onOff(sceneMeta)
+
+    // prefer off methods defined in scene meta
+    if (sceneMeta?.off) {
+      for (const callback of sceneMeta.off) callback()
+      return
+    }
+
+    // otherwise use the default off
+    defaultOff()
+  }
+
+  function setScene(id: string) {
+    activeScene.state = id
+  }
+
+  function _getSceneDef(id: string) {
+    const sceneMeta = scenes.get(id)
+
+    if (!sceneMeta) {
+      throw new InternalError(
+        ctx.context,
+        `[SCENE CONTROLLER][${name.toUpperCase()}][GET META]`,
+        `Scene meta does not exist for: ${activeScene.state}`,
+      )
+    }
+
+    const parsedMeta
+      = typeof sceneMeta.timeout === 'function'
+        ? { ...sceneMeta, timeout: sceneMeta.timeout() }
+        : (sceneMeta as ParsedSceneMeta)
+
+    return parsedMeta
+  }
+
+  return {
+    activate,
+    off,
+    init,
+  }
+}
+
+interface SceneUiControlsInput {
+  ctx: TServiceParams
+  entityType: 'switch' | 'select'
+  scenes: Scenes
+  activeScene: ByIdProxy<PICK_ENTITY<'sensor'>>
+  setScene: (name: string) => void
+}
+
+// handle ui - user inputs & ui state logic
+function sceneUiControls(input: SceneUiControlsInput) {
+  const { ctx, entityType, scenes, activeScene, setScene } = input
+  const defaultSceneName = _getDefaultScene()
+
+  function _generateUiControls() {
+    if (entityType === 'switch')
+      sceneSwitchUi({ ctx, scenes, activeScene, defaultSceneName, setScene })
+  }
+
+  function _getDefaultScene() {
+    let defaultScene: string
+
+    for (const [k, v] of scenes) {
+      if (!v?.isDefault)
+        continue
+
+      defaultScene = k
+    }
+
+    // if no defined default, use the first one & set isDefault true
+    if (!defaultScene) {
+      defaultScene = scenes.keys().next().value
+      scenes.set(defaultScene, { ...scenes.get(defaultScene), isDefault: true })
+    }
+
+    return defaultScene
+  }
+
+  _generateUiControls()
+}
+
+function sceneSwitchUi(input: {
+  ctx: Pick<TServiceParams, 'context' | 'synapse' | 'hass'>
+  scenes: Scenes
+  activeScene: ByIdProxy<PICK_ENTITY<'sensor'>>
+  defaultSceneName: string
+  setScene: (name: string) => void
+}) {
+  const { ctx, scenes, activeScene, defaultSceneName, setScene } = input
+  const switches = [...scenes.entries()].reduce(
+    (switches, [id, sceneMeta]) => {
+      switches.push(
+        generateSwitch({
+          ctx,
+          name: id,
+          icon: sceneMeta.icon,
+          isDefault: sceneMeta.isDefault,
+          activeScene,
+          defaultSceneName,
+          setScene,
+        }),
+      )
+
+      return switches
+    },
+    [] as ReturnType<typeof generateSwitch>[],
+  )
+
+  return switches
+}
+
+function generateSwitch(
+  input: Pick<SceneDef, 'name' | 'isDefault' | 'icon'> & {
+    ctx: Pick<TServiceParams, 'context' | 'synapse'>
+    activeScene: ByIdProxy<PICK_ENTITY<'sensor'>>
+    defaultSceneName: string
+    setScene: (name: string) => void
+  },
+) {
+  const {
+    ctx,
+    name,
+    icon = 'mdi:lightbulb-group',
+    isDefault,
+    activeScene,
+    defaultSceneName,
+    setScene,
+  } = input
+
+  const switchEntity = ctx.synapse.switch({
+    name,
+    icon,
+    device_class: 'switch',
+    context: ctx.context,
+    is_on: {
+      onUpdate: [activeScene],
+      current: () => {
+        if (activeScene.state === name)
+          return true
+
+        if (activeScene.state !== name)
+          return false
+      },
+    },
+    turn_on: () => setScene(name),
+    turn_off: () => {
+      if (!isDefault)
+        setScene(defaultSceneName)
+    },
+  })
+
+  return switchEntity
+}


### PR DESCRIPTION
## 📬 Changes

Manages the state of an area, determining whether it is "occupied" or "vacant" based on presence triggers or a custom callback. Optionally integrates with scene controllers to adjust scenes based on area state.

- ...

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [ ] Tests (added, updated or not needed)
